### PR TITLE
Bump dependencies to support Laravel 9 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.4, '8.0', 8.1]
-        laravel: [8]
+        laravel: [8, 9]
+        exclude:
+          - php: 7.4
+            laravel: 9
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": "^7.4|^8.0",
         "blade-ui-kit/blade-icons": "^1.1",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {


### PR DESCRIPTION
Was going to try out the Laravel 9 beta3, but it wouldn't install because of this package.